### PR TITLE
Add routes, linking for translated languages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -83,5 +83,12 @@ module.exports = {
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,
     `gatsby-plugin-postcss`,
+    {
+      resolve: 'gatsby-plugin-i18n',
+      options: {
+        langKeyDefault: 'en',
+        useLangKeyLayout: false,
+      },
+    },
   ],
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -93,9 +93,8 @@ exports.createPages = async ({ graphql, actions }) => {
     const curLangPosts = posts.filter(
       (p) => p.node.fields.langKey === post.node.fields.langKey
     )
-    const previous =
-      index === curLangPosts.length - 1 ? null : curLangPosts[index + 1].node
-    const next = index === 0 ? null : curLangPosts[index - 1].node
+    const previous = curLangPosts[index + 1]?.node
+    const next = curLangPosts[index - 1]?.node
     const translations =
       translationsByDirectory[post.node.fields.directoryName] || []
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,8 +1,6 @@
 const path = require(`path`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
-const { supportedLanguages } = require('./i18n')
-
-const defaultLang = 'en'
+const { defaultLang, supportedLanguages } = require('./i18n')
 
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,8 @@
 const path = require(`path`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
+const { supportedLanguages } = require('./i18n')
+
+const defaultLang = 'en'
 
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
@@ -16,6 +19,8 @@ exports.createPages = async ({ graphql, actions }) => {
             node {
               fields {
                 slug
+                directoryName
+                langKey
               }
               frontmatter {
                 title
@@ -31,18 +36,77 @@ exports.createPages = async ({ graphql, actions }) => {
     throw result.errors
   }
 
+  // Create index pages for supported languages
+  Object.keys(supportedLanguages).forEach((langKey) =>
+    createPage({
+      path: langKey === defaultLang ? '/' : `/${langKey}`,
+      component: path.resolve('./src/templates/blog-index.js'),
+      context: {
+        langKey,
+      },
+    })
+  )
+
   // Create blog posts pages.
   const posts = result.data.allMarkdownRemark.edges
 
-  posts.forEach((post, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+  const translationsByDirectory = posts.reduce((res, post) => {
+    const directoryName = post.node.fields.directoryName
+    const langKey = post.node.fields.langKey
+
+    if (!langKey || !directoryName || langKey === 'en') {
+      return res
+    }
+
+    res[directoryName] = [...(res[directoryName] || []), langKey]
+    return res
+  })
+
+  const defaultLangPosts = posts.filter(
+    (post) => post.node.fields.langKey === defaultLang
+  )
+
+  defaultLangPosts.forEach((post, index) => {
+    const previous =
+      index === defaultLangPosts.length - 1
+        ? null
+        : defaultLangPosts[index + 1].node
+    const next = index === 0 ? null : defaultLangPosts[index - 1].node
+    const translations =
+      translationsByDirectory[post.node.fields.directoryName] || []
 
     createPage({
       path: post.node.fields.slug,
       component: blogPost,
       context: {
         slug: post.node.fields.slug,
+        previous,
+        next,
+        translations,
+      },
+    })
+  })
+
+  const translatedPosts = posts.filter(
+    (post) => post.node.fields.langKey !== defaultLang
+  )
+
+  translatedPosts.forEach((post, index) => {
+    const curLangPosts = posts.filter(
+      (p) => p.node.fields.langKey === post.node.fields.langKey
+    )
+    const previous =
+      index === curLangPosts.length - 1 ? null : curLangPosts[index + 1].node
+    const next = index === 0 ? null : curLangPosts[index - 1].node
+    const translations =
+      translationsByDirectory[post.node.fields.directoryName] || []
+
+    createPage({
+      path: post.node.fields.slug,
+      component: blogPost,
+      context: {
+        slug: post.node.fields.slug,
+        translations,
         previous,
         next,
       },
@@ -54,11 +118,10 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
   if (node.internal.type === `MarkdownRemark`) {
-    const value = createFilePath({ node, getNode })
     createNodeField({
-      name: `slug`,
+      name: `directoryName`,
       node,
-      value,
+      value: path.basename(path.dirname(node.fileAbsolutePath)),
     })
   }
 }

--- a/i18n.js
+++ b/i18n.js
@@ -6,3 +6,10 @@ exports.supportedLanguages = {
 }
 
 exports.defaultLang = 'en'
+
+exports.langFonts = {
+  en: 'Space Grotesk',
+  'zh-hans': 'Noto Sans SC',
+  'zh-hant': 'Noto Sans TC',
+  ja: 'Noto Sans JP',
+}

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,6 @@
+exports.supportedLanguages = {
+  en: 'English',
+  'zh-hant': '繁體中文',
+  'zh-hans': '简体中文',
+  ja: '日本語',
+}

--- a/i18n.js
+++ b/i18n.js
@@ -4,3 +4,5 @@ exports.supportedLanguages = {
   'zh-hans': '简体中文',
   ja: '日本語',
 }
+
+exports.defaultLang = 'en'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "gatsby": "^2.22.15",
     "gatsby-image": "^2.4.5",
     "gatsby-plugin-catch-links": "^2.3.5",
+    "gatsby-plugin-i18n": "^1.0.1",
     "gatsby-plugin-manifest": "^2.4.9",
     "gatsby-plugin-offline": "^3.2.7",
     "gatsby-plugin-react-helmet": "^3.3.2",
@@ -62,7 +63,11 @@
     }
   },
   "lint-staged": {
-    "*.js": ["prettier --write"],
-    "*.{json,md,mdx}": ["prettier --write"]
+    "*.js": [
+      "prettier --write"
+    ],
+    "*.{json,md,mdx}": [
+      "prettier --write"
+    ]
   }
 }

--- a/src/pages/post1/index.zh-hans.md
+++ b/src/pages/post1/index.zh-hans.md
@@ -1,0 +1,17 @@
+---
+date: '2015-05-06T23:46:37.121Z'
+locale: en
+title: Examine Your Anti-Blackness
+canonical: true
+description: Let's confront our internalized racism
+tags: [tag1, tag2, tag3]
+---
+
+中文
+
+It's time to think deeply about the factors around us that and changing the status quo.
+The Carceral State. The Police State. Despite making up close to 5% of the global population, the U.S. has nearly 25% of the world’s prison population. Since 1970, our incarcerated population has increased by 700% ­­– 2.3 million people in jail and prison today, far outpacing population growth and crime.
+
+One out of every three Black boys born today can expect to go to prison in his lifetime, as can one of every six Latino boys—compared to one of every 17 white boys. At the same time, women are the fastest growing incarcerated population in the United States.
+
+1.  found in translation post 1

--- a/src/pages/post1/index.zh-hans.md
+++ b/src/pages/post1/index.zh-hans.md
@@ -1,17 +1,9 @@
 ---
 date: '2015-05-06T23:46:37.121Z'
-locale: en
 title: Examine Your Anti-Blackness
 canonical: true
 description: Let's confront our internalized racism
 tags: [tag1, tag2, tag3]
 ---
 
-中文
-
-It's time to think deeply about the factors around us that and changing the status quo.
-The Carceral State. The Police State. Despite making up close to 5% of the global population, the U.S. has nearly 25% of the world’s prison population. Since 1970, our incarcerated population has increased by 700% ­­– 2.3 million people in jail and prison today, far outpacing population growth and crime.
-
-One out of every three Black boys born today can expect to go to prison in his lifetime, as can one of every six Latino boys—compared to one of every 17 white boys. At the same time, women are the fastest growing incarcerated population in the United States.
-
-1.  found in translation post 1
+简体中文

--- a/src/pages/post2/index.ja.md
+++ b/src/pages/post2/index.ja.md
@@ -1,9 +1,9 @@
 ---
-date: '2015-05-06T23:46:38.121Z'
+date: '2015-05-06T23:46:37.121Z'
 title: Post2
 canonical: true
 description: 'my second post'
 tags: [tag1, tag2, tag3]
 ---
 
-1.  found in translation post 2
+日本語

--- a/src/pages/post2/index.zh-hans.md
+++ b/src/pages/post2/index.zh-hans.md
@@ -1,9 +1,9 @@
 ---
-date: '2015-05-06T23:46:38.121Z'
+date: '2015-05-06T23:46:37.121Z'
 title: Post2
 canonical: true
 description: 'my second post'
 tags: [tag1, tag2, tag3]
 ---
 
-1.  found in translation post 2
+简体中文

--- a/src/pages/post3/index.en.md
+++ b/src/pages/post3/index.en.md
@@ -1,5 +1,5 @@
 ---
-date: '2015-05-06T23:46:37.121Z'
+date: '2015-05-06T23:46:39.121Z'
 locale: en
 title: Post3
 canonical: true

--- a/src/styles/font-Noto-Sans-JP.css
+++ b/src/styles/font-Noto-Sans-JP.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;300;400;500;700;900&display=swap');

--- a/src/styles/font-Noto-Sans-SC.css
+++ b/src/styles/font-Noto-Sans-SC.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@100;300;400;500;700;900&display=swap');

--- a/src/styles/font-Noto-Sans-TC.css
+++ b/src/styles/font-Noto-Sans-TC.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100;300;400;500;700;900&display=swap');

--- a/src/templates/blog-index.js
+++ b/src/templates/blog-index.js
@@ -5,12 +5,15 @@ import Layout from '../components/layout'
 import Image from '../components/image'
 import SEO from '../components/seo'
 
-const IndexPage = ({ data }) => {
+const IndexPage = ({ data, pageContext, location }) => {
   const siteTitle = data.site.siteMetadata.title
-  const posts = data.allMarkdownRemark.edges
+  const { langKey } = pageContext
+  const posts = data.allMarkdownRemark.edges.filter(
+    ({ node }) => node.fields.langKey === langKey
+  )
 
   return (
-    <Layout>
+    <Layout location={location}>
       <SEO title="All posts" />
       {posts.map(({ node }) => {
         const title = node.frontmatter.title || node.fields.slug
@@ -52,6 +55,7 @@ export const pageQuery = graphql`
           excerpt
           fields {
             slug
+            langKey
           }
           frontmatter {
             date(formatString: "MMMM DD, YYYY")

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -3,11 +3,31 @@ import { Link, graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 import SEO from '../components/seo'
+import { defaultLang, supportedLanguages } from '../../i18n'
+
+const getSlugByLang = (langKey, slug, srcLang) => {
+  const rawSlug = slug.replace(`${srcLang}/`, '')
+  return `${langKey}${rawSlug}`
+}
 
 const BlogPostTemplate = ({ data, pageContext, location }) => {
   const post = data.markdownRemark
+  const { langKey, slug } = data.markdownRemark.fields
+  const { previous, next, translations } = pageContext
   const siteTitle = data.site.siteMetadata.title
-  const { previous, next } = pageContext
+
+  const translatedLinks = translations
+    .filter((lK) => lK !== langKey)
+    .concat(langKey !== defaultLang ? [defaultLang] : [])
+    .map((translatedLangKey) => (
+      <Link
+        to={getSlugByLang(translatedLangKey, slug, langKey)}
+        key={translatedLangKey}
+        className="font-medium hover:font-semibold text-xl"
+      >
+        {supportedLanguages[translatedLangKey]}
+      </Link>
+    ))
 
   return (
     <Layout location={location} title={siteTitle}>
@@ -18,13 +38,8 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
       <article>
         <header className="mb-8">
           <span className="text-4xl">{post.frontmatter.title}</span>
-          <p
-            style={{
-              display: `block`,
-            }}
-          >
-            {post.frontmatter.date}
-          </p>
+          <p className="text-lg mb-4">{post.frontmatter.date}</p>
+          {translatedLinks}
         </header>
         <section
           className="markdown"
@@ -53,6 +68,10 @@ export const pageQuery = graphql`
         date(formatString: "MMMM DD, YYYY")
         description
         tags
+      }
+      fields {
+        slug
+        langKey
       }
     }
   }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -23,7 +23,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
       <Link
         to={getSlugByLang(translatedLangKey, slug, langKey)}
         key={translatedLangKey}
-        className="font-medium hover:font-semibold text-xl"
+        className="font-medium hover:font-semibold text-xl mr-4"
       >
         {supportedLanguages[translatedLangKey]}
       </Link>

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -3,7 +3,8 @@ import { Link, graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 import SEO from '../components/seo'
-import { defaultLang, supportedLanguages } from '../../i18n'
+import { defaultLang, supportedLanguages, langFonts } from '../../i18n'
+import { loadFontForLang } from '../utils/i18n'
 
 const getSlugByLang = (langKey, slug, srcLang) => {
   const rawSlug = slug.replace(`${srcLang}/`, '')
@@ -16,6 +17,8 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
   const { previous, next, translations } = pageContext
   const siteTitle = data.site.siteMetadata.title
 
+  translations.concat(langKey).forEach((langKey) => loadFontForLang(langKey))
+
   const translatedLinks = translations
     .filter((lK) => lK !== langKey)
     .concat(langKey !== defaultLang ? [defaultLang] : [])
@@ -24,6 +27,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
         to={getSlugByLang(translatedLangKey, slug, langKey)}
         key={translatedLangKey}
         className="font-medium hover:font-semibold text-xl mr-4"
+        style={{ fontFamily: langFonts[translatedLangKey] }}
       >
         {supportedLanguages[translatedLangKey]}
       </Link>
@@ -43,6 +47,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
         </header>
         <section
           className="markdown"
+          style={{ fontFamily: langFonts[langKey] }}
           dangerouslySetInnerHTML={{ __html: post.html }}
         />
       </article>

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-unused-expressions */
+
+export const loadFontForLang = (langKey) => {
+  switch (langKey) {
+    case 'ja':
+      import('../styles/font-Noto-Sans-JP.css')
+      break
+    case 'zh-hans':
+      import('../styles/font-Noto-Sans-SC.css')
+      break
+    case 'zh-hant':
+      import('../styles/font-Noto-Sans-TC.css')
+      break
+    default:
+      break
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6742,6 +6742,11 @@ focus-lock@^0.6.7:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.8.tgz#61985fadfa92f02f2ee1d90bc738efaf7f3c9f46"
   integrity sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==
 
+folktale@^2.0.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/folktale/-/folktale-2.3.2.tgz#38231b039e5ef36989920cbf805bf6b227bf4fd4"
+  integrity sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==
+
 follow-redirects@1.5.10, follow-redirects@^1.0.0:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -7069,6 +7074,15 @@ gatsby-plugin-catch-links@^2.3.5:
   dependencies:
     "@babel/runtime" "^7.10.2"
     escape-string-regexp "^1.0.5"
+
+gatsby-plugin-i18n@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-i18n/-/gatsby-plugin-i18n-1.0.1.tgz#573fb98b85654c29e0cda50740037061fa38e694"
+  integrity sha512-6Cucb15sLQp9cTVgmRC34MeWVJu0a09G7LRrCNV87PgMlbS5iVUX00TwDnIUB0b+f6RUq3z5+V6/sIBIvsz8/Q==
+  dependencies:
+    folktale "^2.0.1"
+    graphql "^0.11.7"
+    ptz-i18n "^1.0.0"
 
 gatsby-plugin-manifest@^2.4.9:
   version "2.4.9"
@@ -7977,6 +7991,13 @@ graphql-type-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.1.tgz#47fca2b1fa7adc0758d165b33580d7be7a6cf548"
   integrity sha512-1lPkUXQ2L8o+ERLzVAuc3rzc/E6pGF+6HnjihCVTK0VzR0jCuUd92FqNxoHdfILXqOn2L6b4y47TBxiPyieUVA==
+
+graphql@^0.11.7:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
+  integrity sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==
+  dependencies:
+    iterall "1.1.3"
 
 graphql@^14.6.0:
   version "14.6.0"
@@ -9444,6 +9465,11 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
+
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+  integrity sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ==
 
 iterall@^1.2.1, iterall@^1.2.2, iterall@^1.3.0:
   version "1.3.0"
@@ -12342,6 +12368,14 @@ psl@^1.1.28:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
+ptz-i18n@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ptz-i18n/-/ptz-i18n-1.0.0.tgz#803df4d0f5ce9a7732f5d1d805ea624c6a1f5e8c"
+  integrity sha512-3buuv2T+Qo2tyo3A1pSx2arxheW0vd+tPGizmWdvr9RWJKfQlrNw8GtnYXdjChUKN0s2UO/JJkWswOTRYBi/OQ==
+  dependencies:
+    folktale "^2.0.1"
+    ramda "^0.24.1"
+
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -12459,6 +12493,11 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
+ramda@^0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
+  integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"


### PR DESCRIPTION
the language picker could use a visual update but we haven't decided how things should look at all yet so that is TBD

dynamically loads fonts per language, though this is a little complicated and causes flickering when waiting for fonts to load. we could just switch to including Noto on all pages, pending deciding which set of languages are supported

translated routes are of the format `/ISO 639 Language Key/postname`, i.e. `/en/post1` becomes `/ja/post1`, `/zh-hans/post1`, etc

TODO in another PR: load correct language versions on different language index pages i.e. `/zh-hans` currently loads `/post1/index.en.md` but it should load `/post1/index.zh-hans.md`

![output](https://user-images.githubusercontent.com/3166481/85643425-ea1ea980-b648-11ea-96c0-4096e7cd487d.gif)
